### PR TITLE
Fixed custom stylesheets not overwriting those from Quasar

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -87,10 +87,11 @@ export default defineNuxtModule<ModuleOptions>({
       nuxt.options.css.push(...options.extras.fontIcons.map(resolveFontIcon))
     }
 
+    // Quasar css is inserted at the start to ensure custom stylesheets in will be able to overwrite without the use of !important.
     if (options.sassVariables) {
-      nuxt.options.css.push('quasar/src/css/index.sass')
+      nuxt.options.css.unshift('quasar/src/css/index.sass')
     } else {
-      nuxt.options.css.push('quasar/dist/quasar.css')
+      nuxt.options.css.unshift('quasar/dist/quasar.css')
     }
 
     const { version: quasarVersion } = await importJSON('quasar/package.json')


### PR DESCRIPTION
Ensured the Quasar CSS is now inserted at the start of the `nuxt.options.css` array. This means the custom stylesheets can overwrite the css of Quasar because the will be loaded afterwards. 


```ts
// nuxt.config.ts
export default defineNuxtConfig({

	/*
	 ** Global CSS: https://nuxt.com/docs/api/configuration/nuxt-config#css
	 */
	css: ['@/assets/scss/style.scss'],
}
```

How it currently is:

![image](https://user-images.githubusercontent.com/15127381/226116058-a9a89a4b-9aea-4523-aeef-5c0466c8d5f8.png)
