### PR TITLE
feat: Partially synced SSR context between Nuxt and Quasar

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { App as VueApp } from 'vue'
 import type { QVueGlobals, QuasarIconSet, QuasarLanguage } from 'quasar'
 import type { ModuleOptions } from './module'
@@ -83,4 +84,21 @@ export interface QuasarPluginServerContext {
   lang: QuasarLanguage
   iconSet: QuasarIconSet
   ssrContext: any
+}
+
+export interface QuasarSSRContext {
+  req: IncomingMessage
+  res: ServerResponse
+  $q: any
+  _meta: {
+    htmlAttrs: string
+    headTags: string
+    endingHeadTags: string
+    bodyClasses: string
+    bodyAttrs: string
+    bodyTags: string
+  }
+  _modules: any[]
+  onRendered: ((...args: any[]) => any)[]
+  __qPrevLang: string
 }


### PR DESCRIPTION
This change syncs quasar and nuxt's SSR context to a certain extent.

This allows quasar to modify rendered html (outside of vue context) before being sent to client. Currently only body classes and html attributes are supported.