### PR TITLE
Add NPM Publish Workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,45 @@
+on:
+  release:
+    types: [released] # Should only trigger on published releases, and non pre-releases/drafts
+
+jobs:
+  publish-to-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 7
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        # dev:prepare is needed since we extend from the ./playground/.nuxt/tsconfig.json in ./tsconfig.json
+        run: pnpm install && pnpm dev:prepare
+
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          check-version: true


### PR DESCRIPTION
Hi there, 

As mentioned in https://github.com/Maiquu/nuxt-quasar/pull/17, this will build and publish Nuxt-Quasar to the NPM registry. 

To make this work on this repository you will need to add a NPM access token to the repository settings. 

1. [Generate the access token](https://docs.npmjs.com/creating-and-viewing-access-tokens)
2. Add it to this repository settings, like this:

![image](https://user-images.githubusercontent.com/15127381/227556074-553dda2f-f075-4c7a-ac26-a702389c68a8.png)

Make sure the name is exactly `NPM_TOKEN`

3. When you publish a new Github release, it will automatically be send to the NPM registery. 

I tested this out and the result can be seen here: https://www.npmjs.com/package/jason-nuxt-quasar-ui

Let me know if you have any questions!