### PR TITLE
Added composable to set the Quasar default values through a Nuxt plugin

### DIFF
--- a/playground/components/PropDefaults.vue
+++ b/playground/components/PropDefaults.vue
@@ -2,7 +2,6 @@
 import {ref} from "#imports";
 
 const toggle = ref(true);
-const progress = ref(0.5);
 </script>
 
 
@@ -31,7 +30,7 @@ const progress = ref(0.5);
           Q-Linear-Progress with green as the default color:
         </td>
         <td>
-          <QLinearProgress value="progress" indeterminate/>
+          <QLinearProgress indeterminate/>
         </td>
       </tr>
     </q-markup-table>

--- a/playground/components/PropDefaults.vue
+++ b/playground/components/PropDefaults.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import {ref} from "#imports";
+
+const toggle = ref(true);
+const progress = ref(0.5);
+</script>
+
+
+<template>
+  <div>
+    <p>Default Quasar Prop values can be set in <code>"/plugins/quasar-prop-defaults.ts"</code></p>
+    <q-markup-table style="max-width: 600px;">
+      <tr>
+        <td>
+          Q-CircularProgress with blue as the default color:
+        </td>
+        <td>
+          <QCircularProgress/>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Q-toggle with red as the default color:
+        </td>
+        <td>
+          <QToggle v-model="toggle"/>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Q-toggle with green as the default color:
+        </td>
+        <td>
+          <QLinearProgress value="progress" indeterminate/>
+        </td>
+      </tr>
+    </q-markup-table>
+  </div>
+</template>
+

--- a/playground/components/PropDefaults.vue
+++ b/playground/components/PropDefaults.vue
@@ -8,32 +8,34 @@ const toggle = ref(true);
 <template>
   <div>
     <p>Default Quasar Prop values can be set in <code>"/plugins/quasar-prop-defaults.ts"</code></p>
-    <q-markup-table style="max-width: 600px;">
-      <tr>
-        <td>
-          Q-CircularProgress with blue as the default color:
-        </td>
-        <td>
-          <QCircularProgress/>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Q-Toggle with red as the default color:
-        </td>
-        <td>
-          <QToggle v-model="toggle"/>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Q-Linear-Progress with green as the default color:
-        </td>
-        <td>
-          <QLinearProgress indeterminate/>
-        </td>
-      </tr>
-    </q-markup-table>
+    <QMarkupTable style="max-width: 600px;">
+      <tbody>
+        <tr>
+          <td>
+            Q-CircularProgress with blue as the default color:
+          </td>
+          <td>
+            <QCircularProgress />
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Q-Toggle with red as the default color:
+          </td>
+          <td>
+            <QToggle v-model="toggle"/>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Q-Linear-Progress with green as the default color:
+          </td>
+          <td>
+            <QLinearProgress indeterminate/>
+          </td>
+        </tr>
+      </tbody>
+    </QMarkupTable>
   </div>
 </template>
 

--- a/playground/components/PropDefaults.vue
+++ b/playground/components/PropDefaults.vue
@@ -20,7 +20,7 @@ const progress = ref(0.5);
       </tr>
       <tr>
         <td>
-          Q-toggle with red as the default color:
+          Q-Toggle with red as the default color:
         </td>
         <td>
           <QToggle v-model="toggle"/>
@@ -28,7 +28,7 @@ const progress = ref(0.5);
       </tr>
       <tr>
         <td>
-          Q-toggle with green as the default color:
+          Q-Linear-Progress with green as the default color:
         </td>
         <td>
           <QLinearProgress value="progress" indeterminate/>

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -111,5 +111,9 @@ const buttons: QBtnProps[] = [
       Directive Showcase
     </p>
     <example-list />
+    <p class="text-h6 q-pt-md">
+      Quasar Default Prop Values
+    </p>
+    <prop-defaults />
   </q-page>
 </template>

--- a/playground/plugins/quasar-defaults.ts
+++ b/playground/plugins/quasar-defaults.ts
@@ -1,0 +1,35 @@
+import {
+  QCircularProgress,
+  QInput,
+  QLinearProgress,
+  QSelect,
+  QToggle,
+} from 'quasar'
+import { defineNuxtPlugin } from '#app'
+import { useQuasarPropDefaults } from '#imports'
+
+export default defineNuxtPlugin(() => {
+  useQuasarPropDefaults(QInput, {
+    outlined: true,
+  })
+
+  useQuasarPropDefaults(QSelect, {
+    outlined: true,
+    dense: true,
+  })
+
+  useQuasarPropDefaults(QToggle, {
+    color: 'red',
+  })
+
+  useQuasarPropDefaults(QCircularProgress, {
+    color: 'blue',
+    indeterminate: true,
+  })
+
+  useQuasarPropDefaults(QLinearProgress, {
+    color: 'green',
+    size: '15px',
+    stripe: true,
+  })
+})

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,13 @@
 import { readFile } from 'node:fs/promises'
-import { addComponent, addImports, addImportsSources, addPluginTemplate, defineNuxtModule, resolvePath } from '@nuxt/kit'
+import {
+  addComponent,
+  addImports,
+  addImportsSources,
+  addPluginTemplate,
+  createResolver,
+  defineNuxtModule,
+  resolvePath
+} from '@nuxt/kit'
 import type { ViteConfig } from '@nuxt/schema'
 import type { QuasarAnimations, QuasarFonts, QuasarLanguageCodes } from 'quasar'
 import type { AssetURLOptions } from 'vue/compiler-sfc'
@@ -103,7 +111,7 @@ export default defineNuxtModule<ModuleOptions>({
     const imports = await categorizeImports(importMap)
 
     setupCss(nuxt.options.css, options)
-
+    setupQuasarDefaultPropExports()
     addPluginTemplate({
       mode: 'client',
       filename: 'quasar-plugin.mjs',
@@ -295,6 +303,15 @@ async function getIconsFromIconset(iconSet: QuasarSvgIconSets): Promise<string[]
 
     return icons
   }
+}
+
+export function setupQuasarDefaultPropExports() {
+  const resolver = createResolver(import.meta.url)
+  addImports({
+    name: 'useQuasarPropDefaults',
+    as: 'useQuasarPropDefaults',
+    from: resolver.resolve('runtime/composables/quasar-prop-defaults'),
+  })
 }
 
 /**

--- a/src/module.ts
+++ b/src/module.ts
@@ -330,7 +330,7 @@ function setupComposables() {
  * @param css
  * @param options
  */
-function setupCss(css: string[], options: ModuleOptions) {
+export function setupCss(css: string[], options: ModuleOptions) {
   // Quasar CSS is inserted at the start to ensure custom stylesheets will be able to overwrite styles without the use of !important.
   const quasarCssActualPath = options.sassVariables
     ? 'quasar/src/css/index.sass'

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,7 +6,7 @@ import {
   addPluginTemplate,
   createResolver,
   defineNuxtModule,
-  resolvePath
+  resolvePath,
 } from '@nuxt/kit'
 import type { ViteConfig } from '@nuxt/schema'
 import type { QuasarAnimations, QuasarFonts, QuasarLanguageCodes } from 'quasar'
@@ -111,7 +111,8 @@ export default defineNuxtModule<ModuleOptions>({
     const imports = await categorizeImports(importMap)
 
     setupCss(nuxt.options.css, options)
-    setupQuasarDefaultPropExports()
+    setupComposables()
+
     addPluginTemplate({
       mode: 'client',
       filename: 'quasar-plugin.mjs',
@@ -305,7 +306,7 @@ async function getIconsFromIconset(iconSet: QuasarSvgIconSets): Promise<string[]
   }
 }
 
-export function setupQuasarDefaultPropExports() {
+function setupComposables() {
   const resolver = createResolver(import.meta.url)
   addImports({
     name: 'useQuasarPropDefaults',
@@ -329,7 +330,7 @@ export function setupQuasarDefaultPropExports() {
  * @param css
  * @param options
  */
-export function setupCss(css: string[], options: ModuleOptions) {
+function setupCss(css: string[], options: ModuleOptions) {
   // Quasar CSS is inserted at the start to ensure custom stylesheets will be able to overwrite styles without the use of !important.
   const quasarCssActualPath = options.sassVariables
     ? 'quasar/src/css/index.sass'
@@ -383,7 +384,7 @@ export function setupCss(css: string[], options: ModuleOptions) {
  *
  * @param config
  */
-export function muteQuasarSassWarnings(config: ViteConfig) {
+function muteQuasarSassWarnings(config: ViteConfig) {
   // Source of this fix: https://github.com/quasarframework/quasar/pull/12034#issuecomment-1021503176
   const silenceSomeSassDeprecationWarnings: SassOptions<'sync'> = {
     verbose: true,

--- a/src/runtime/composables/quasar-prop-defaults.ts
+++ b/src/runtime/composables/quasar-prop-defaults.ts
@@ -1,0 +1,34 @@
+// Source: https://github.com/quasarframework/quasar/discussions/8761#discussioncomment-1042529
+import type { ComponentConstructor } from 'quasar'
+
+type ExtractComponentProps<T> = T extends ComponentConstructor<infer X> ? X['$props'] : never
+/**
+ * Sets the default prop values for a Quasar component
+ * @param component
+ * @param propDefaults
+ */
+export const useQuasarPropDefaults = <T extends ComponentConstructor>(
+  component: T,
+  propDefaults: {
+    [K in keyof Partial<ExtractComponentProps<T>>]: ExtractComponentProps<T>[K];
+  },
+) => {
+  for (const key in propDefaults) {
+    const prop = component.props[key]
+    switch (typeof prop) {
+      case 'object':
+        prop.default = propDefaults[key]
+        break
+      case 'function':
+        component.props[key] = {
+          type: prop,
+          default: propDefaults[key],
+        }
+        break
+      case 'undefined':
+        throw new Error(`Nuxt-Quasar - The Quasar prop type was undefined on key '${key}', this happened when setting the Quasar default prop values`)
+      default:
+        throw new Error(`Nuxt-Quasar - An unknown Quasar prop type with '${typeof prop}' was set to configure the default prop values`)
+    }
+  }
+}


### PR DESCRIPTION
This implements: #35 

This is how the PlayGround looks:

![image](https://user-images.githubusercontent.com/15127381/230570845-d03a0cbc-b370-48e3-9ac7-9e73e7e70c6b.png)
