### PR TITLE
Brand property "dark-page" was added in types

### DIFF
--- a/playground/assets/quasar-variables.sass
+++ b/playground/assets/quasar-variables.sass
@@ -3,6 +3,7 @@ $secondary : #26A69A
 $accent    : #9C27B0
 
 $dark      : #1D1D1D
+$dark-page : #121212
 
 $positive  : #21BA45
 $negative  : #C10015

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,7 @@ export interface QuasarFrameworkInnerConfiguration {
     secondary?: string
     accent?: string
     dark?: string
+    'dark-page'?: string
     positive?: string
     negative?: string
     info?: string


### PR DESCRIPTION
The “QuasarFrameworkInnerConfiguration” interface doesn't specify the “dark-page” property in the “brand” object. The property is specified in the official documentation and defines background color of pages:

![image](https://github.com/Maiquu/nuxt-quasar/assets/14940878/68268e62-de99-4504-be62-eebb63352a8a)

Missing of this property leads to typescript's error in a code editor:

![quasar-plugin](https://github.com/Maiquu/nuxt-quasar/assets/14940878/d973c1a7-f6a7-4f41-9216-b256804ed391)

I've added this property to `src/types.ts` and set it in the playground.

