### PR TITLE
Fix wrong type for svgIcons & fontIcons

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -82,9 +82,9 @@ export interface ModuleOptions {
   extras?: {
     font?: QuasarFonts | null
     /** Icons that are imported as webfont. */
-    fontIcons?: QuasarFontIconSet[]
+    fontIcons?: QuasarFontIconSets[]
     /** Automaticly import selected svg icon sets provided by `@quasar/extras`. */
-    svgIcons?: QuasarSvgIconSet[]
+    svgIcons?: QuasarSvgIconSets[]
     /** Animations provided by quasar.
      *
      * @see [Documentation](https://quasar.dev/options/animations)

--- a/src/module.ts
+++ b/src/module.ts
@@ -83,7 +83,7 @@ export interface ModuleOptions {
     font?: QuasarFonts | null
     /** Icons that are imported as webfont. */
     fontIcons?: QuasarFontIconSets[]
-    /** Automaticly import selected svg icon sets provided by `@quasar/extras`. */
+    /** Automatically import selected svg icon sets provided by `@quasar/extras`. */
     svgIcons?: QuasarSvgIconSets[]
     /** Animations provided by quasar.
      *


### PR DESCRIPTION
svgIcons & fontIcons must be of type QuasarFontIconSets[] by spec, otherwise auto-imports fail and the fields are left unusable.