### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@
 ```bash
 # Using pnpm
 pnpm add quasar @quasar/extras
-pnpm add -D nuxt-quasar-ui
+npx nuxi@latest module add quasar
 
 # Using yarn
 yarn add quasar @quasar/extras
-yarn add --dev nuxt-quasar-ui
+npx nuxi@latest module add quasar
 
 # Using npm
 npm install quasar @quasar/extras
-npm install --save-dev nuxt-quasar-ui
+npx nuxi@latest module add quasar
 ```
 
 2. Add `nuxt-quasar-ui` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
