### PR TITLE
Fix deprecation warning due to use of @import instead of the newer @use

### DIFF
--- a/src/plugins/transform/scss.ts
+++ b/src/plugins/transform/scss.ts
@@ -44,10 +44,10 @@ export function transformScssPlugin({ options }: ModuleContext): VitePlugin {
 }
 
 function createScssTransform(fileExtension: string, sassVariables?: string | boolean): (code: string) => string {
-  const sassImportCode = ['@import \'quasar/src/css/variables.sass\'', '']
+  const sassImportCode = ['@use \'quasar/src/css/variables.sass\' as *', '']
 
   if (typeof sassVariables === 'string') {
-    sassImportCode.unshift(`@import '${sassVariables}'`)
+    sassImportCode.unshift(`@use '${sassVariables}'`)
   }
 
   const prefix = fileExtension === 'sass'


### PR DESCRIPTION
Hi there!

With the later/latest version of SASS, `@import` has been deprecated in favor of `@use`. 

When configuring a  `sassVariables` option like this: 
```ts
	quasar: {
		sassVariables: '@/assets/scss/_variables.scss',
	},
```

Nuxt throws many warnings like this:

```bash
Deprecation Warning: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
10 │ @import '@/assets/scss/_variables.scss'
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/quasar/dist/quasar.sass 10:9  root stylesheet
```

Changing the  `@import` to `@use` will fix these warnings.

 